### PR TITLE
Cleanup language statistics in the repository's main page

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+backend/engines/* linguist-detectable=false


### PR DESCRIPTION
Currently, GitHub shows that most of the code in this project is written in C++.

![image](https://github.com/dfdiazc/chess-engine-interface/assets/80299581/84c6f426-2a5e-4c4f-b023-2ac22ccd54dc)

This is probably due to the `backup/engines`  folder. This PR creates the `.gitattributes` file and sets it to ignore all contents inside this folder to calculate the language statistics.

Is there anything else that we should ignore?